### PR TITLE
Fix possible issue when reading value count

### DIFF
--- a/Tibialyzer/Managers/GlobalDataManager.cs
+++ b/Tibialyzer/Managers/GlobalDataManager.cs
@@ -38,7 +38,7 @@ namespace Tibialyzer {
         }
 
         public static long GetLootValue() {
-            return lootValue;
+            return System.Threading.Interlocked.Read(ref lootValue);
         }
 
         public static void ClearLootValue() {


### PR DESCRIPTION
Reading this value could technically be an issue on 32-bit systems. Although, in practice, this should never be an issue since we don't expect several reads from multiple threads while simultaneously updating the value since this is based on user input. Still, better to be safe than have issues crop up later.