### PR TITLE
Resolve performance issues

### DIFF
--- a/Tibialyzer/Controls/CurveBar.cs
+++ b/Tibialyzer/Controls/CurveBar.cs
@@ -29,15 +29,13 @@ using System.Windows.Forms;
 
 namespace Tibialyzer {
     public class CurveBar : Control {
-        private Timer updateTimer;
+        private SafeTimer updateTimer;
 
         private float health = 1;
         private float mana = 1;
 
         public CurveBar() {
-            updateTimer = new Timer();
-            updateTimer.Interval = 10;
-            updateTimer.Tick += updateTimer_Tick;
+            updateTimer = new SafeTimer(10, updateTimer_Tick);
             updateTimer.Start();
         }
         
@@ -47,7 +45,7 @@ namespace Tibialyzer {
             }
         }
 
-        private void updateTimer_Tick(object sender, EventArgs e) {
+        private void updateTimer_Tick() {
             health = (float)MemoryReader.Health / MemoryReader.MaxHealth;
             mana = (float)MemoryReader.Mana / MemoryReader.MaxMana;
             try {
@@ -55,6 +53,7 @@ namespace Tibialyzer {
                 this.Invoke((MethodInvoker)delegate {
                     this.Visible = visible;
                 });
+
             } catch {
             }
             this.Invalidate();

--- a/Tibialyzer/Controls/MapPictureBox.cs
+++ b/Tibialyzer/Controls/MapPictureBox.cs
@@ -55,6 +55,7 @@ namespace Tibialyzer {
         public Point3D nextConnectionPoint = new Point3D(-1, -1, -1);
         TibiaPath playerPath = null;
         public event MapUpdatedHandler MapUpdated;
+        SafeTimer refreshTimer;
 
         public MapPictureBox() {
             mapImage = null;
@@ -66,6 +67,7 @@ namespace Tibialyzer {
             paths = new List<TibiaPath>();
             map = null;
             otherMap = null;
+            refreshTimer = new SafeTimer(50, RefreshMapTimer);
         }
 
         protected override void Dispose(bool disposing) {
@@ -102,28 +104,21 @@ namespace Tibialyzer {
             }
         }
 
-        System.Timers.Timer refreshTimer = new System.Timers.Timer();
+        
         public void SetTargetCoordinate(Coordinate coordinate) {
             this.targetCoordinate = coordinate;
-            refreshTimer = new System.Timers.Timer(50);
-            refreshTimer.Elapsed += RefreshMapTimer;
-            refreshTimer.Enabled = true;
+            refreshTimer.Start();
         }
 
         private object mapBoxLock = new object();
-        private void RefreshMapTimer(object sender, System.Timers.ElapsedEventArgs e) {
+        private void RefreshMapTimer() {
             if (this.IsDisposed) return;
             try {
-                refreshTimer.Dispose();
-                refreshTimer = null;
                 this.Invoke((MethodInvoker)delegate {
                     UpdateMap(true);
                 });
-                refreshTimer = new System.Timers.Timer(50);
-                refreshTimer.Elapsed += RefreshMapTimer;
-                refreshTimer.Enabled = true;
-            } catch {
 
+            } catch {
             }
         }
 

--- a/Tibialyzer/HUDs/HealthList.cs
+++ b/Tibialyzer/HUDs/HealthList.cs
@@ -85,14 +85,13 @@ namespace Tibialyzer {
             this.Load += HealthList_Load;
         }
 
-        private System.Timers.Timer timer;
+        private SafeTimer timer;
         private void HealthList_Load(object sender, EventArgs e) {
-            timer = new System.Timers.Timer(10);
-            timer.Elapsed += Timer_Elapsed;
+            timer = new SafeTimer(10, Timer_Elapsed);
             timer.Start();
         }
 
-        private void Timer_Elapsed(object sender, System.Timers.ElapsedEventArgs e) {
+        private void Timer_Elapsed() {
             RefreshHealth();
         }
         
@@ -164,19 +163,13 @@ namespace Tibialyzer {
         }
 
         public void RefreshHealth() {
-            timer.Enabled = false;
             try {
                 bool visible = ProcessManager.IsTibiaActive();
                 this.Invoke((MethodInvoker)delegate {
                     RefreshHUD();
                     this.Visible = visible;
                 });
-                timer.Enabled = true;
             } catch {
-                if (timer != null) {
-                    timer.Dispose();
-                    timer = null;
-                }
             }
         }
 

--- a/Tibialyzer/HUDs/Portrait.cs
+++ b/Tibialyzer/HUDs/Portrait.cs
@@ -86,15 +86,13 @@ namespace Tibialyzer {
             this.Load += Portrait_Load;
         }
 
-        private Timer timer;
+        private SafeTimer timer;
         private void Portrait_Load(object sender, EventArgs e) {
-            timer = new Timer();
-            timer.Interval = 10;
-            timer.Tick += Timer_Tick;
+            timer = new SafeTimer(10, Timer_Tick);
             timer.Start();
         }
         
-        private void Timer_Tick(object sender, EventArgs e) {
+        private void Timer_Tick() {
             RefreshStats();
         }
 

--- a/Tibialyzer/HUDs/StatusBar.cs
+++ b/Tibialyzer/HUDs/StatusBar.cs
@@ -55,15 +55,13 @@ namespace Tibialyzer {
             }
         }
 
-        private Timer timer;
+        private SafeTimer timer;
         private void StatusBar_Load(object sender, EventArgs e) {
-            timer = new Timer();
-            timer.Interval = 10;
-            timer.Tick += Timer_Tick;
+            timer = new SafeTimer(10, Timer_Tick);
             timer.Start();
         }
         
-        private void Timer_Tick(object sender, EventArgs e) {
+        private void Timer_Tick() {
             RefreshHealth();
         }
 

--- a/Tibialyzer/Managers/CommandManager.cs
+++ b/Tibialyzer/Managers/CommandManager.cs
@@ -194,16 +194,9 @@ namespace Tibialyzer {
                         if (timeInSeconds <= notificationWarningTime) {
                             PopupManager.ShowSimpleNotification(new SimpleTimerNotification(iconImage, title, message, timeInSeconds));
                         } else {
-                            System.Timers.Timer timer = new System.Timers.Timer(1000 * (timeInSeconds - notificationWarningTime));
-                            timer.Elapsed += (sender, e) => {
-                                timer.Enabled = false;
-                                timer.Dispose();
-
-                                MainForm.mainForm.Invoke((MethodInvoker)delegate {
-                                    PopupManager.ShowSimpleNotification(new SimpleTimerNotification(iconImage, title, message, notificationWarningTime));
-                                });
-                            };
-                            timer.Enabled = true;
+                            MainForm.mainForm.Invoke((MethodInvoker)delegate {
+                                System.Threading.Tasks.Task.Delay(1000 * (timeInSeconds - notificationWarningTime)).ContinueWith(x => PopupManager.ShowSimpleNotification(new SimpleTimerNotification(iconImage, title, message, notificationWarningTime))).Start();
+                            });
                         }
                     }
                 } else if (comp.StartsWith("exp" + Constants.CommandSymbol)) { //exp@

--- a/Tibialyzer/Managers/GlobalDataManager.cs
+++ b/Tibialyzer/Managers/GlobalDataManager.cs
@@ -36,17 +36,14 @@ namespace Tibialyzer {
         private static bool DamageUpdated = false;
         private static bool WasteUpdated = false;
         private static bool ExperienceUpdated = false;
-        private static System.Windows.Forms.Timer updateTimer;
+        private static SafeTimer updateTimer;
 
         public static void Initialize() {
-            updateTimer = new System.Windows.Forms.Timer();
-            updateTimer.Interval = 50;
-            updateTimer.Tick += UpdateTimer_Tick;
+            updateTimer = new SafeTimer(50, UpdateTimer_Tick);
             updateTimer.Start();
-
         }
 
-        private static void UpdateTimer_Tick(object sender, EventArgs e) {
+        private static void UpdateTimer_Tick() {
             LootDatabaseManager.LootUpdatedEvent();
 
             if (DamageUpdated) {

--- a/Tibialyzer/Popups/PopupContainer.cs
+++ b/Tibialyzer/Popups/PopupContainer.cs
@@ -5,7 +5,7 @@ using System.Data;
 using System.Drawing;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
+using System.Threading;
 using System.Windows.Forms;
 
 namespace Tibialyzer {
@@ -64,10 +64,7 @@ namespace Tibialyzer {
                 notifications.Add(controls);
                 controls.Add(background);
 
-                System.Timers.Timer closeTimer = new System.Timers.Timer(Math.Max(SettingsManager.getSettingInt("PopupDuration"), 1) * 1000);
-                closeTimer.Elapsed += CloseTimer_Elapsed;
-                closeTimer.Enabled = true;
-                closeTimer.AutoReset = false;
+                System.Threading.Tasks.Task.Delay(Math.Max(SettingsManager.getSettingInt("PopupDuration"), 1) * 1000).ContinueWith(t => ClosePopup()).Start();
             }
         }
 
@@ -109,7 +106,7 @@ namespace Tibialyzer {
             }
         }
 
-        private void CloseTimer_Elapsed(object sender, System.Timers.ElapsedEventArgs e) {
+        private void ClosePopup() {
             this.Invoke((MethodInvoker)delegate {
                 lock (notificationLock) {
                     if (notifications.Count == 0) return;

--- a/Tibialyzer/SafeTimer.cs
+++ b/Tibialyzer/SafeTimer.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Timers;
+
+namespace Tibialyzer
+{
+    public sealed class SafeTimer : IDisposable
+    {
+        private Timer timer;
+
+        public SafeTimer(double interval, Action action)
+        {
+            timer = new Timer(interval);
+            timer.AutoReset = false;
+            timer.Elapsed += (s, e) =>
+            {
+                action();
+                timer.Start();
+            };
+        }
+
+        ~SafeTimer()
+        {
+            Dispose(false);
+        }
+
+        public void Start() {
+            timer.Start();
+        }
+
+        public void Stop() {
+            timer.Stop();
+        }
+
+        public double Interval
+        {
+            get {
+                return timer.Interval;
+            }
+            set {
+                timer.Interval = value;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // free managed resources
+                if (timer != null)
+                {
+                    timer.Dispose();
+                    timer = null;
+                }
+            }
+        }
+    }
+}

--- a/Tibialyzer/Tibialyzer.csproj
+++ b/Tibialyzer/Tibialyzer.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Popups\SimpleTimerNotification.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="SafeTimer.cs" />
     <Compile Include="SelectProcessForm.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
There were two related issues that were causing the performance issues. There were timers that were firing faster than they could finish. This in itself was causing plenty of issues. The other issue was that all of these timers wanted to query the current running processes in order to see if they should display UI components or not. querying the current running processes every few milliseconds from several threads was eating up a lot of CPU. Instead, I queried the processes every 100ms and cache the result. Saw CPU utilization drop from ~25% to ~8% usage.