### PR TITLE
Require an exact match for the form title

### DIFF
--- a/Tibialyzer/Managers/AutoHotkeyManager.cs
+++ b/Tibialyzer/Managers/AutoHotkeyManager.cs
@@ -35,9 +35,9 @@ namespace Tibialyzer {
             if (!SettingsManager.settingExists("AutoHotkeySettings")) return;
             using (StreamWriter writer = new StreamWriter(Constants.AutohotkeyFile)) {
                 writer.WriteLine("#SingleInstance force");
+                writer.WriteLine("SetTitleMatchMode 3");
                 if (ProcessManager.IsFlashClient()) {
                     Process p = ProcessManager.GetTibiaProcess();
-                    writer.WriteLine("SetTitleMatchMode 2");
                     writer.WriteLine(String.Format("#IfWinActive Tibia Flash Client", p == null ? 0 : p.Id));
                 } else {
                     writer.WriteLine("#IfWinActive ahk_class TibiaClient");


### PR DESCRIPTION
Commit a4635d56dd5e7a67809a7986ffd2f60ef7a2ee41 (OBS changes) also included some window name changes that included "Tibialyzer". This change now requires an exact match for the window name. This is required because the message handling must happen on the MainForm inside of the WndProc override.