### PR TITLE
Fix ClampCoordinate logic that was setting Z coordinate to 15 all the time

### DIFF
--- a/Tibialyzer/Structures/Coordinate.cs
+++ b/Tibialyzer/Structures/Coordinate.cs
@@ -49,7 +49,7 @@ namespace Tibialyzer {
         public void ClampCoordinate() {
             this.x = Math.Min(Math.Max(x, 0), MaxWidth);
             this.y = Math.Min(Math.Max(y, 0), MaxHeight);
-            this.z = Math.Min(Math.Max(x, 0), MaxZ);
+            this.z = Math.Min(Math.Max(z, 0), MaxZ);
         }
     }
 


### PR DESCRIPTION
This was broken by: https://github.com/Mytherin/Tibialyzer/commit/5a620b902316f761256245d3504d2992f513d2d5#diff-e9a6a21bf713dab84cf081b9e2dc1f7cR52

Looks like a simple mistake `x` for `z` there.