### PR TITLE
The "Screenshot on Low Life"-Checkbox is initialised now

### DIFF
--- a/Tibialyzer/Tabs/ScreenshotTab.cs
+++ b/Tibialyzer/Tabs/ScreenshotTab.cs
@@ -22,6 +22,7 @@ namespace Tibialyzer {
             this.screenshotAdvanceCheckbox.Checked = SettingsManager.getSettingBool("AutoScreenshotAdvance");
             this.screenshotOnRareItemCheckbox.Checked = SettingsManager.getSettingBool("AutoScreenshotItemDrop");
             this.screenshotDeathCheckbox.Checked = SettingsManager.getSettingBool("AutoScreenshotDeath");
+            this.screenshotLowLifeCheckbox.Checked = SettingsManager.getSettingBool("AutoScreenshotLowLife");
             this.screenshotValueBox.Text = SettingsManager.getSettingString("ScreenshotRareItemValue");
 
             this.enableScreenshotCheckbox.Checked = SettingsManager.getSettingBool("EnableScreenshots");


### PR DESCRIPTION
The Option itself worked correctly, but when you restarted the Tibialyzer it didnt display the current status.

The Issue is also mentioned at  #295